### PR TITLE
v2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "token-tooltip-alt",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1690,7 +1690,7 @@
       }
     },
     "foundry-pc-types": {
-      "version": "gitlab:foundry-projects/foundry-pc/foundry-pc-types#e5e18df82f426775ad220427a62177baafeb3120",
+      "version": "gitlab:foundry-projects/foundry-pc/foundry-pc-types#5e91ccc17be1916c922d628c9d783dd04d6f8b69",
       "from": "gitlab:foundry-projects/foundry-pc/foundry-pc-types",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "token-tooltip-alt",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "",
   "scripts": {
     "package": "gulp package",

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
   "name": "token-tooltip-alt",
   "title": "Token Tooltip Alt",
   "description": "A module that adds a tooltip next to the currently hovered token to show some useful information for players and DMs.",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "author": "bmarian",
   "esmodules": ["token-tooltip-alt.js"],
   "styles": ["token-tooltip-alt.css"],

--- a/src/styles/tooltip.scss
+++ b/src/styles/tooltip.scss
@@ -40,6 +40,9 @@
 
   & i {
     min-width: 1.5ch;
+    @supports (-moz-appearance:none) {
+      min-width: 2.7ch;
+    }
     padding-right: 5px;
     text-align: center;
     flex: 1;


### PR DESCRIPTION
- Fixed missing template "settings-editor-row.hbs" closes #37 
- Fixed icon overlap in firefox closes #38 