### PR TITLE
Fix for token tooltips not being shown when ALT is held

### DIFF
--- a/scripts/TTAFoundryApiIntegration/Hooks/TTAHooks.js
+++ b/scripts/TTAFoundryApiIntegration/Hooks/TTAHooks.js
@@ -54,7 +54,7 @@ const hookHandlers = {
     return addHookHandler('hoverToken', HOOK_TYPE.ON, TooltipFactory.hoverToken.bind(TooltipFactory));
   },
   refreshTokenHandler() {
-    return addHookHandler('refreshToken', HOOK_TYPE.ON, TooltipFactory.hoverToken.bind(TooltipFactory)); // Check to show tooltips if ALT is held
+    return addHookHandler('refreshToken', HOOK_TYPE.ON, TooltipFactory.refreshToken.bind(TooltipFactory));
   },
   removeTooltipHandlers() {
     ['preUpdateToken', 'canvasPan', 'deleteToken'].forEach((hook) => {

--- a/scripts/TTAFoundryApiIntegration/Hooks/TTAHooks.js
+++ b/scripts/TTAFoundryApiIntegration/Hooks/TTAHooks.js
@@ -53,6 +53,9 @@ const hookHandlers = {
   hoverTokenHandler() {
     return addHookHandler('hoverToken', HOOK_TYPE.ON, TooltipFactory.hoverToken.bind(TooltipFactory));
   },
+  refreshTokenHandler() {
+    return addHookHandler('refreshToken', HOOK_TYPE.ON, TooltipFactory.hoverToken.bind(TooltipFactory)); // Check to show tooltips if ALT is held
+  },
   removeTooltipHandlers() {
     ['preUpdateToken', 'canvasPan', 'deleteToken'].forEach((hook) => {
       addHookHandler(hook, HOOK_TYPE.ON, TooltipFactory.removeTooltips.bind(TooltipFactory));

--- a/scripts/TooltipFactory.js
+++ b/scripts/TooltipFactory.js
@@ -122,6 +122,16 @@ class TooltipFactory {
     }
     this[isHovering ? '_addTooltip' : '_removeTooltip'](token);
   }
+  
+  // public hook whenever a token is refreshed
+  async refreshToken(token, extra) {	
+    console.log(token);
+	if (!token?.actor || !this._shouldActorHaveTooltip(token)) { return; }
+	// Check if this refresh was caused by alt being pressed, and if so should tooltips render
+    const altHeldRenderTooltip = this._isAltPressed() && this._getAltSettings().showOnAlt &&	
+									(token?.document?.hidden ? this._getAltSettings().showAllOnAlt : true);
+    this[altHeldRenderTooltip ? '_addTooltip' : '_removeTooltip'](token);
+  }
 
   // public hook to remove all tooltips
   removeTooltips() {

--- a/scripts/TooltipFactory.js
+++ b/scripts/TooltipFactory.js
@@ -117,7 +117,7 @@ class TooltipFactory {
     if (isAltPressed) {
       const altSettings = this._getAltSettings();
       if (!altSettings.showOnAlt) { return; }
-      const isTokenHidden = token?.data?.hidden;
+      const isTokenHidden = token?.document?.hidden;
       if (altSettings.showOnAlt && !altSettings.showAllOnAlt && isTokenHidden) { return; }
     }
     this[isHovering ? '_addTooltip' : '_removeTooltip'](token);

--- a/scripts/TooltipFactory.js
+++ b/scripts/TooltipFactory.js
@@ -126,10 +126,10 @@ class TooltipFactory {
   // public hook whenever a token is refreshed
   async refreshToken(token, extra) {	
     console.log(token);
-	if (!token?.actor || !this._shouldActorHaveTooltip(token)) { return; }
-	// Check if this refresh was caused by alt being pressed, and if so should tooltips render
+    if (!token?.actor || !this._shouldActorHaveTooltip(token)) { return; }
+    // Check if this refresh was caused by alt being pressed, and if so should tooltips render
     const altHeldRenderTooltip = this._isAltPressed() && this._getAltSettings().showOnAlt &&	
-									(token?.document?.hidden ? this._getAltSettings().showAllOnAlt : true);
+                                 (token?.document?.hidden ? this._getAltSettings().showAllOnAlt : true);
     this[altHeldRenderTooltip ? '_addTooltip' : '_removeTooltip'](token);
   }
 

--- a/scripts/TooltipFactory.js
+++ b/scripts/TooltipFactory.js
@@ -124,8 +124,7 @@ class TooltipFactory {
   }
   
   // public hook whenever a token is refreshed
-  async refreshToken(token, extra) {	
-    console.log(token);
+  async refreshToken(token) {	
     if (!token?.actor || !this._shouldActorHaveTooltip(token)) { return; }
     // Check if this refresh was caused by alt being pressed, and if so should tooltips render
     const altHeldRenderTooltip = this._isAltPressed() && this._getAltSettings().showOnAlt &&	


### PR DESCRIPTION
It seems this module relied on the 'hoverToken' hook to show all visible tokens' tooltips when ALT was held because that would also cause Foundry to highlight all visible tokens and when doing so considered those tokens hovered, and so the hoverToken hook was called. But it seems at some point Foundry v10 either added a new hook 'refreshToken' or started to use it instead of hoverToken whenever ALT was held down to highlight tokens, causing the handler for this module to not be called and no tooltips to be show. I simply added the original hoverToken handler to the refreshToken hook as well, so it is once again called when the ALT key is pressed. 

I also noticed from a console warning that a line of code was still using 'token.data' as an accessor which v10 marks as deprecated, so that has been changed to 'token.document'.
