### PR TITLE
use token.document for v10 displaynames

### DIFF
--- a/scripts/Tooltip.js
+++ b/scripts/Tooltip.js
@@ -228,7 +228,7 @@ class Tooltip {
   // for players this gets a little complicated
   _getActorDisplayName(staticData) {
     if (!staticData) return null;
-    const tokenDataSource = versionAfter10() ? this._token : this._token?.data;
+    const tokenDataSource = versionAfter10() ? this._token?.document : this._token?.data;
     const tokenName = tokenDataSource?.name;
     if (this._tooltipInfo.isGM && staticData.displayNameInTooltip) return tokenName;
     if (!this._tooltipInfo.isGM) {


### PR DESCRIPTION
# Description
This PR fixes the path to the token data to find the token's disposition and enables players to see token names via the tooltip (based on permissions/disposition) once again.

## Issue Number
Closes #111